### PR TITLE
Decode HTML entities in URLs before extracting mfid

### DIFF
--- a/src/utils/mfid.mts
+++ b/src/utils/mfid.mts
@@ -1,6 +1,9 @@
 // An MFID, short for "Mastofeed identifier", is a short base64 string representing the unique identifier of an RSS item.
 // It allows Mastofeed to keep track of which RSS items have already been posted to Mastodon.
 
+import { decode as decodeHtmlEntities } from "html-entities";
+
+
 export function encodeMFID(decoded: string): string {
   return Buffer.from(decoded).toString("base64");
 }
@@ -14,8 +17,17 @@ export function extractUrlFromTootContent(content: string): string {
   if (matches.length === 0 || matches[matches.length - 1].length !== 2) {
     throw new Error(`Failed to extract URL from toot content '${content}'.`);
   }
-  // If the toot contains multiple links, we want to extract the last one.
-  return matches[matches.length - 1][1];
+
+  // If the toot contains multiple links, we want to extract the last one:
+  const targetMatch = matches[matches.length - 1][1];
+
+  // Check if anything that _could_ be an HTML entity is present:
+  if (!/&(?:[a-zA-Z]+|#\d+|#x[\da-fA-F]+);/.test(targetMatch)) {
+    return targetMatch;                       // no entities → return as-is
+  }
+
+  // Something that _could_ be an entity is present; decode and return the result.
+  return decodeHtmlEntities(targetMatch);
 }
 
 export function extractMFIDFromUrl(url: string): string {

--- a/test/unit/mfid.test.mts
+++ b/test/unit/mfid.test.mts
@@ -25,6 +25,17 @@ describe("Mastofeed identifier (MFID)", () => {
     );
   });
 
+  it("extracts an URL and decodes HTML entities from a toot's content (see issue #1)", () => {
+    expect(
+      extractUrlFromTootContent(
+        '<p>BLOCS SANITAIRES DANS LES ÉCOLES <br />Drainville exige le maintien de toilettes non mixtes</p><p>Hugo Pilon-Larose — Actualités<br /><a href="https://github.com/cdzombak/gallerygen/tree/main?tab=readme-ov-file&amp;mfid=aHR0cHM6Ly9naXRodWIuY29tL2Nkem9tYmFrL2dhbGxlcnlnZW4vdHJlZS9tYWluP3RhYj1yZWFkbWUtb3YtZmlsZQ%3D%3D" target="_blank" rel="nofollow noopener noreferrer" translate="no"><span class="invisible">https://www.</span><span class="ellipsis">lapresse.ca/actualites/educati</span><span class="invisible">on/2023-09-12/blocs-sanitaires-dans-les-ecoles/drainville-exige-le-maintien-de-toilettes-non-mixtes.php?mfid=MDE1MzZiOWY0NWY3M2EzZWI0OGEwM2UzMTBjMDBjMWU=</span></a></p>',
+      ),
+    ).toEqual(
+      "https://github.com/cdzombak/gallerygen/tree/main?tab=readme-ov-file&mfid=aHR0cHM6Ly9naXRodWIuY29tL2Nkem9tYmFrL2dhbGxlcnlnZW4vdHJlZS9tYWluP3RhYj1yZWFkbWUtb3YtZmlsZQ%3D%3D",
+    );
+  });
+
+
   it("adds an MFID to a URL", () => {
     expect(addMFIDToUrl("https://www.example.com/test?utm=foo", "375c0c80e35f3c5494478cab7343fa13")).toEqual(
       "https://www.example.com/test?utm=foo&mfid=Mzc1YzBjODBlMzVmM2M1NDk0NDc4Y2FiNzM0M2ZhMTM%3D",
@@ -35,5 +46,10 @@ describe("Mastofeed identifier (MFID)", () => {
     expect(
       extractMFIDFromUrl("https://www.example.com/test?utm=foo&mfid=Mzc1YzBjODBlMzVmM2M1NDk0NDc4Y2FiNzM0M2ZhMTM%3D"),
     ).toEqual("375c0c80e35f3c5494478cab7343fa13");
+  });
+
+  it("extracts an MFID from URL (see issue #1)", () => {
+    const res = extractMFIDFromUrl("https://github.com/cdzombak/gallerygen/tree/main?tab=readme-ov-file&mfid=aHR0cHM6Ly9naXRodWIuY29tL2Nkem9tYmFrL2dhbGxlcnlnZW4vdHJlZS9tYWluP3RhYj1yZWFkbWUtb3YtZmlsZQ%3D%3D");
+    expect(res).toEqual("https://github.com/cdzombak/gallerygen/tree/main?tab=readme-ov-file");
   });
 });


### PR DESCRIPTION
Closes: https://github.com/pascal-giguere/mastofeed/issues/1

I have verified on my own feed that this fixes the issue I reported.